### PR TITLE
Clear busy flag before starting new custom effect

### DIFF
--- a/server/services/lifx-udp.ts
+++ b/server/services/lifx-udp.ts
@@ -550,6 +550,8 @@ export class LifxUDPService extends EventEmitter {
   // New method to handle complex JSON effects
   public async applyCustomEffect(deviceIdStr: string, mac: string, ip: string, effectData: any, loopCount: number = 1) {
     console.log('[applyCustomEffect] Received effectData:', JSON.stringify(effectData));
+    // Clear busy flag from any recently stopped effect so new effects aren't ignored
+    this.busyDevices.delete(mac);
     if (this.busyDevices.has(mac)) {
       console.log(`[applyCustomEffect] Device ${mac} is busy, ignoring new effect request at ${new Date().toISOString()}`);
       return;


### PR DESCRIPTION
## Summary
- ensure `applyCustomEffect` clears busy flag so new effects start immediately

## Testing
- `npm run check` *(fails: Property errors in several TS files)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f06305483339c980bbb4dcb9cad