### PR TITLE
Fix effect command blocking

### DIFF
--- a/server/services/lifx-udp.ts
+++ b/server/services/lifx-udp.ts
@@ -363,6 +363,9 @@ export class LifxUDPService extends EventEmitter {
     // Save current state before applying effect
     await this.saveDeviceState(target);
 
+    // Clear any command blocking set by a previous effect restore
+    this.blockedUntil.delete(target);
+
     switch (effectType) {
       case 'flash':
         this.flashEffect(target, address, duration);
@@ -574,6 +577,9 @@ export class LifxUDPService extends EventEmitter {
 
     // Save current device state before applying effect
     await this.saveDeviceState(mac);
+
+    // Clear any command blocking set by a previous effect restore
+    this.blockedUntil.delete(mac);
 
     // Create a new cancellation token for this effect
     const cancelToken = { cancelled: false };


### PR DESCRIPTION
## Summary
- reset `blockedUntil` when starting new light effects so commands aren't skipped

## Testing
- `npm run check` *(fails: Property 'brightness' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f079f7483338e3bdef37b5dd382