### PR TITLE
Support delay fields in LIFX custom effects

### DIFF
--- a/server/services/lifx-udp.ts
+++ b/server/services/lifx-udp.ts
@@ -586,6 +586,10 @@ export class LifxUDPService extends EventEmitter {
     const delay = (ms: number) => new Promise(res => setTimeout(res, ms));
 
     const runSteps = async () => {
+      const globalDelay = effectData.globalDelay || 0;
+      if (globalDelay > 0) {
+        await delay(globalDelay);
+      }
       while (!cancelToken.cancelled && (isInfiniteLoop || currentLoop < maxLoops)) {
         for (let i = 0; i < effectData.steps.length; i++) {
           if (cancelToken.cancelled) {
@@ -609,6 +613,10 @@ export class LifxUDPService extends EventEmitter {
           const duration = step.duration || 1000;
           this.setColor(mac, ip, color, duration);
           await delay(duration);
+          const stepDelay = step.delay || 0;
+          if (stepDelay > 0) {
+            await delay(stepDelay);
+          }
         }
         currentLoop++;
       }


### PR DESCRIPTION
## Summary
- respect `globalDelay` before custom effect loops start
- honor per-step `delay` pauses when running a custom effect

## Testing
- `npm run check` *(fails: cannot compile TypeScript project)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f0895448333bd5d1422f24b901f