### PR TITLE
Support editing full effect JSON

### DIFF
--- a/client/src/components/add-effect-modal.tsx
+++ b/client/src/components/add-effect-modal.tsx
@@ -106,9 +106,8 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
         };
       }
       
-      // Extract just the steps array for the JSON editor
-      const stepsArray = jsonData.steps || [];
-      setCustomEffectJson(JSON.stringify(stepsArray, null, 2));
+      // Provide full custom JSON for the editor
+      setCustomEffectJson(JSON.stringify(jsonData, null, 2));
       
       // Set form fields from JSON data
       setCustomEffectLoop(jsonData.loop || false);
@@ -171,9 +170,8 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
         };
       }
       
-      // Extract just the steps array for the JSON editor
-      const stepsArray = jsonData.steps || [];
-      setCustomEffectJson(JSON.stringify(stepsArray, null, 2));
+      // Provide full custom JSON for the editor
+      setCustomEffectJson(JSON.stringify(jsonData, null, 2));
       
       // Set form fields from JSON data
       setCustomEffectLoop(jsonData.loop || false);
@@ -234,19 +232,17 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
       });
     } else if (effectType === 'lighting') {
       if (!sceneName) return;
-      // Parse and validate the steps JSON
-      let stepsArray = [];
+      // Parse and validate the custom effect JSON
+      let customEffect: any = {};
       if (customEffectJson) {
         try {
-          stepsArray = JSON.parse(customEffectJson);
-          if (!Array.isArray(stepsArray)) {
-            throw new Error('Steps must be an array');
-          }
+          customEffect = JSON.parse(customEffectJson);
         } catch (error) {
-          console.error('Invalid steps JSON:', error);
+          console.error('Invalid effect JSON:', error);
           return;
         }
       }
+      const stepsArray = Array.isArray(customEffect.steps) ? customEffect.steps : [];
       // Extract colors from steps for gradient
       let extractedColors = stepsArray
         .map((step: any) => step.color)
@@ -261,9 +257,9 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
       const completeEffect = {
         name: sceneName,
         description: sceneDescription || undefined,
-        loop: customEffectLoop,
-        loopCount: customEffectLoopCount,
-        globalDelay: customEffectGlobalDelay,
+        loop: customEffect.loop ?? customEffectLoop,
+        loopCount: customEffect.loopCount ?? customEffectLoopCount,
+        globalDelay: customEffect.globalDelay ?? customEffectGlobalDelay,
         steps: stepsArray
       };
       // Create a lighting effect
@@ -396,6 +392,15 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
       deviceIds: ["1", "2"]
     }
   ];
+
+  const exampleEffect = {
+    name: "My Effect",
+    description: "Example lighting effect",
+    loop: false,
+    loopCount: 1,
+    globalDelay: 0,
+    steps: exampleSteps
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -791,21 +796,21 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
             </div>
 
             <div>
-              <Label className="text-white">Effect Steps (JSON Array)</Label>
+              <Label className="text-white">Effect JSON</Label>
               <Textarea
                 value={customEffectJson}
                 onChange={(e) => setCustomEffectJson(e.target.value)}
-                placeholder="Enter steps array only..."
+                placeholder="Enter full custom effect JSON..."
                 className="bg-slate-800 border-slate-700 text-white h-32 font-mono text-sm"
               />
               <div className="mt-2 text-xs text-slate-400">
                 <details>
-                  <summary className="cursor-pointer hover:text-slate-300">View steps example</summary>
+                  <summary className="cursor-pointer hover:text-slate-300">View example</summary>
                   <pre className="mt-2 bg-slate-900 p-2 rounded text-xs overflow-x-auto">
-{JSON.stringify(exampleSteps, null, 2)}
+{JSON.stringify(exampleEffect, null, 2)}
                   </pre>
                 </details>
-                <p className="mt-2">Only enter the steps array - the name, description, loop settings will be added automatically from the form fields above.</p>
+                <p className="mt-2">Enter the entire custom effect JSON structure.</p>
               </div>
             </div>
           </TabsContent>


### PR DESCRIPTION
## Summary
- allow editing the complete custom effect object instead of only the steps
- load and save the entire JSON for lighting effects

## Testing
- `npm run check` *(fails: TS errors in server code)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f07ff4c8333b00c2360862b6e81