### PR TITLE
Fix missing customJson when saving new light effect

### DIFF
--- a/client/src/components/add-effect-modal.tsx
+++ b/client/src/components/add-effect-modal.tsx
@@ -262,7 +262,10 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
         globalDelay: customEffect.globalDelay ?? customEffectGlobalDelay,
         steps: stepsArray
       };
-      // Create a lighting effect
+      // Create a lighting effect and persist customJson at the top level so
+      // it is available when editing later.  Without this field, the edit
+      // dialog falls back to a default template and loses the user supplied
+      // steps.
       const lightingEffect = {
         name: sceneName,
         description: sceneDescription || undefined,
@@ -271,6 +274,9 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
         configuration: {
           customJson: completeEffect
         },
+        // Store the effect JSON at the root level as well for easier access
+        customJson: completeEffect,
+        isCustom: true,
         colors: extractedColors,
         hiddenFromDashboard: hiddenFromDashboard
       };


### PR DESCRIPTION
## Summary
- ensure new custom light effects keep their customJson at the top level

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_687a53b36cec83339a08ec4e36ecd1ae