### PR TITLE
Support editing full effect JSON

### DIFF
--- a/client/src/components/add-effect-modal.tsx
+++ b/client/src/components/add-effect-modal.tsx
@@ -22,7 +22,7 @@ import LightingEffects from "./lighting-effects";
 interface AddEffectModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSaveSound: (data: InsertSoundButton & { audioFile: File }) => void;
+  onSaveSound: (data: Omit<InsertSoundButton, 'audioFile'> & { audioFile: File }) => void;
   onSaveScene: (data: InsertScene & { turnOnIfOff?: boolean; deviceSettings?: any }) => void;
   onSaveLightingEffect: (data: any) => void; // <-- add this
   onDeleteScene?: (id: number) => void;
@@ -85,7 +85,7 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
       let jsonData = (editingScene as any).customJson;
       if (!jsonData) {
         // Convert legacy scene to JSON format
-        const config = editingScene.configuration;
+        const config = editingScene.configuration as any;
         jsonData = {
           name: editingScene.name,
           description: editingScene.description || '',
@@ -106,9 +106,8 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
         };
       }
       
-      // Extract just the steps array for the JSON editor
-      const stepsArray = jsonData.steps || [];
-      setCustomEffectJson(JSON.stringify(stepsArray, null, 2));
+      // Provide full custom JSON for the editor
+      setCustomEffectJson(JSON.stringify(jsonData, null, 2));
       
       // Set form fields from JSON data
       setCustomEffectLoop(jsonData.loop || false);
@@ -142,19 +141,19 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
     if (editingLightingEffect) {
       setEffectType('lighting');
       setSceneName(editingLightingEffect.name);
-      setSceneDescription(editingLightingEffect.description || '');
-      setSceneIcon(editingLightingEffect.icon || 'zap');
+      setSceneDescription((editingLightingEffect as any).description || '');
+      setSceneIcon((editingLightingEffect as any).icon || 'zap');
       
       // All effects now show as custom with JSON data
       setSceneType('custom');
       
       // Convert effect to JSON format for editing
-      let jsonData = editingLightingEffect.customJson;
+      let jsonData = editingLightingEffect.customJson as any;
       if (!jsonData) {
         // Convert legacy effect to JSON format
         jsonData = {
           name: editingLightingEffect.name,
-          description: editingLightingEffect.description || '',
+          description: (editingLightingEffect as any).description || '',
           loop: false,
           loopCount: 1,
           globalDelay: 0,
@@ -171,9 +170,8 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
         };
       }
       
-      // Extract just the steps array for the JSON editor
-      const stepsArray = jsonData.steps || [];
-      setCustomEffectJson(JSON.stringify(stepsArray, null, 2));
+      // Provide full custom JSON for the editor
+      setCustomEffectJson(JSON.stringify(jsonData, null, 2));
       
       // Set form fields from JSON data
       setCustomEffectLoop(jsonData.loop || false);
@@ -234,19 +232,17 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
       });
     } else if (effectType === 'lighting') {
       if (!sceneName) return;
-      // Parse and validate the steps JSON
-      let stepsArray = [];
+      // Parse and validate the custom effect JSON
+      let customEffect: any = {};
       if (customEffectJson) {
         try {
-          stepsArray = JSON.parse(customEffectJson);
-          if (!Array.isArray(stepsArray)) {
-            throw new Error('Steps must be an array');
-          }
+          customEffect = JSON.parse(customEffectJson);
         } catch (error) {
-          console.error('Invalid steps JSON:', error);
+          console.error('Invalid effect JSON:', error);
           return;
         }
       }
+      const stepsArray = Array.isArray(customEffect.steps) ? customEffect.steps : [];
       // Extract colors from steps for gradient
       let extractedColors = stepsArray
         .map((step: any) => step.color)
@@ -261,9 +257,9 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
       const completeEffect = {
         name: sceneName,
         description: sceneDescription || undefined,
-        loop: customEffectLoop,
-        loopCount: customEffectLoopCount,
-        globalDelay: customEffectGlobalDelay,
+        loop: customEffect.loop ?? customEffectLoop,
+        loopCount: customEffect.loopCount ?? customEffectLoopCount,
+        globalDelay: customEffect.globalDelay ?? customEffectGlobalDelay,
         steps: stepsArray
       };
       // Create a lighting effect
@@ -397,6 +393,15 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
     }
   ];
 
+  const exampleEffect = {
+    name: "My Effect",
+    description: "Example lighting effect",
+    loop: false,
+    loopCount: 1,
+    globalDelay: 0,
+    steps: exampleSteps
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto bg-slate-900 border-slate-700">
@@ -474,7 +479,7 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
                   </SelectTrigger>
                   <SelectContent className="bg-slate-800 border-slate-700">
                     <SelectItem value="none" className="text-white">No lighting effect</SelectItem>
-                    {lightEffects.filter(effect => effect.customJson?.loopCount !== 0).map((effect) => (
+                    {lightEffects.filter(effect => (effect.customJson as any)?.loopCount !== 0).map((effect) => (
                       <SelectItem key={effect.id} value={effect.id.toString()} className="text-white">
                         {effect.name}
                       </SelectItem>
@@ -791,21 +796,21 @@ export function AddEffectModal({ isOpen, onClose, onSaveSound, onSaveScene, onSa
             </div>
 
             <div>
-              <Label className="text-white">Effect Steps (JSON Array)</Label>
+              <Label className="text-white">Effect JSON</Label>
               <Textarea
                 value={customEffectJson}
                 onChange={(e) => setCustomEffectJson(e.target.value)}
-                placeholder="Enter steps array only..."
+                placeholder="Enter full custom effect JSON..."
                 className="bg-slate-800 border-slate-700 text-white h-32 font-mono text-sm"
               />
               <div className="mt-2 text-xs text-slate-400">
                 <details>
-                  <summary className="cursor-pointer hover:text-slate-300">View steps example</summary>
+                  <summary className="cursor-pointer hover:text-slate-300">View example</summary>
                   <pre className="mt-2 bg-slate-900 p-2 rounded text-xs overflow-x-auto">
-{JSON.stringify(exampleSteps, null, 2)}
+{JSON.stringify(exampleEffect, null, 2)}
                   </pre>
                 </details>
-                <p className="mt-2">Only enter the steps array - the name, description, loop settings will be added automatically from the form fields above.</p>
+                <p className="mt-2">Enter the entire custom effect JSON structure.</p>
               </div>
             </div>
           </TabsContent>

--- a/client/src/components/device-management.tsx
+++ b/client/src/components/device-management.tsx
@@ -13,9 +13,9 @@ const getDeviceStatusColor = (device: Device) => {
   }
   
   // If device uses temperature/kelvin (white light)
-  if (device.color?.kelvin && device.color.kelvin > 0) {
+  if ((device.color as any)?.kelvin && (device.color as any).kelvin > 0) {
     // Convert kelvin to RGB-ish color
-    const kelvin = device.color.kelvin;
+    const kelvin = (device.color as any).kelvin;
     let r, g, b;
     
     if (kelvin <= 2000) {
@@ -40,10 +40,10 @@ const getDeviceStatusColor = (device: Device) => {
   }
   
   // If device uses color (HSV/HSB)
-  if (device.color?.hue !== undefined && device.color?.saturation !== undefined) {
-    const hue = (device.color.hue / 65535) * 360;
-    const saturation = device.color.saturation / 65535;
-    const brightness = ((device.color.brightness || device.brightness || 100) / 65535) * 100;
+  if ((device.color as any)?.hue !== undefined && (device.color as any)?.saturation !== undefined) {
+    const hue = ((device.color as any).hue / 65535) * 360;
+    const saturation = (device.color as any).saturation / 65535;
+    const brightness = (((device.color as any).brightness || device.brightness || 100) / 65535) * 100;
     
     // Convert HSV to RGB
     const c = (brightness / 100) * saturation;

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "@types/connect-pg-simple": "^7.0.3",
         "@types/express": "4.17.21",
         "@types/express-session": "^1.18.0",
-        "@types/node": "^20.16.11",
+        "@types/node": "^20.19.8",
         "@types/passport": "^1.0.16",
         "@types/passport-local": "^1.0.38",
         "@types/react": "^18.3.11",
@@ -3477,12 +3477,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.16.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
-      "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
+      "version": "20.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
+      "integrity": "sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/passport": {
@@ -8387,9 +8387,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",
-    "@types/node": "^20.16.11",
+    "@types/node": "^20.19.8",
     "@types/passport": "^1.0.16",
     "@types/passport-local": "^1.0.38",
     "@types/react": "^18.3.11",


### PR DESCRIPTION
## Summary
- allow editing the complete custom effect object instead of only the steps
- load and save the entire JSON for lighting effects
- cast unknown data when reading existing config and effects
- widen device color accessors to avoid strict errors
- bump `@types/node`

## Testing
- `npm run check` *(fails: TS errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f07ff4c8333b00c2360862b6e81